### PR TITLE
[FIX]product_multiple_barcodes: check only the limited products

### DIFF
--- a/product_multiple_barcodes/tests/test_merp_product_barcode_multi.py
+++ b/product_multiple_barcodes/tests/test_merp_product_barcode_multi.py
@@ -8,24 +8,18 @@ class TestMerpProductBarcodeMulti(TransactionCase):
 
     def setUp(self):
         super(TestMerpProductBarcodeMulti, self).setUp()
-        barcode_1 = self.env['product.barcode.multi'].create({
-            'name': 'test001'
-        })
-        barcode_2 = self.env['product.barcode.multi'].create({
-            'name': 'test002'
-        })
         self.product_1 = self.env['product.template'].create({
             'name': 'product_1',
             'barcode': 'test003',
-            'barcode_ids': [(4, barcode_1.id)]
+            'barcode_ids': [(0, 0, {'name': 'test001'})]
         })
         self.product_2 = self.env['product.template'].create({
             'name': 'product_2',
-            'barcode_ids': [(4, barcode_2.id)]
+            'barcode_ids': [(0, 0, {'name': 'test002'})]
         })
         self.product_3 = self.env['product.product'].create({
             'name': 'product_2',
-            'barcode_ids': [(4, barcode_2.id)]
+            'barcode_ids': [(0, 0, {'name': 'test004'})]
         })
 
         ctx = self.env.context.copy()


### PR DESCRIPTION
Old Version: it was looping over all the products and checking/grouping all products and its barcode & barcode ids-->name

problem: it was having a problem when we have a long list of products it was slowing down the system.

New version: make a list of the current product's(the product which has been changed) barcode. and checking existing product/barcode for that. 

Also fixed some test cases which was failing because on not null constraints of `product_id` in `product.barcode.multi`