### PR TITLE
[FIX]maximum recursion depth error in case compute method not called …

### DIFF
--- a/merp_outgoing_routing/models/stock_location.py
+++ b/merp_outgoing_routing/models/stock_location.py
@@ -31,8 +31,15 @@ class StockLocation(models.Model):
 
         res = self.sudo().search([], order='{} {}'.format(
             field, ['asc', 'desc'][int(strategy_order)]))
+        processed = self.env['stock.location']
         for sequence, location in enumerate(res):
+            if location not in self:
+                continue
             location.strategy_sequence = sequence
+            processed |= location
+        remaining_locations = self - processed
+        for remaining in remaining_locations:
+            remaining.strategy_sequence = 1000
 
     @api.onchange('location_id')
     def _onchange_parent_location(self):

--- a/merp_outgoing_routing/models/stock_location.py
+++ b/merp_outgoing_routing/models/stock_location.py
@@ -38,8 +38,9 @@ class StockLocation(models.Model):
             location.strategy_sequence = sequence
             processed |= location
         remaining_locations = self - processed
+        max_seq = len(res)
         for remaining in remaining_locations:
-            remaining.strategy_sequence = 1000
+            remaining.strategy_sequence =  max_seq
 
     @api.onchange('location_id')
     def _onchange_parent_location(self):


### PR DESCRIPTION
…for all location and we assign value for all location

When the for few locations the compute method has called.
and we do not have other location data in the cache.
when we assign strategy_sequence value to the location(whose value not in self) it is giving RecursionError: maximum recursion depth exceeded

