### PR TITLE
Fix: (17.0) _name_search hook on product.product

### DIFF
--- a/product_multiple_barcodes/models/product_product.py
+++ b/product_multiple_barcodes/models/product_product.py
@@ -21,14 +21,13 @@ class ProductProduct(models.Model):
     ]
 
     @api.model
-    def _name_search(self, name, args=None, operator='ilike', limit=100, order=None):
-        args = args or []
-        domain = []
+    def _name_search(self, name, domain=None, operator='ilike', limit=None, order=None):
+        domain = domain or []
         if name:
-            domain = ['|', '|', ('name', operator, name), ('default_code', operator, name),
+            barcode_domain = ['|', '|', ('name', operator, name), ('default_code', operator, name),
                       '|', ('barcode', operator, name), ('barcode_ids', operator, name)]
-        return self._search(expression.AND([domain, args]),
-                                  limit=limit, order=order)
+            domain = expression.AND([domain, barcode_domain])
+        return super()._name_search(name, domain=domain, operator=operator, limit=limit, order=order)
 
     @api.constrains('barcode', 'barcode_ids', 'active')
     def _check_unique_barcode(self):


### PR DESCRIPTION
updated hook to call super function to allow Other hooks to this function to be called.

The current hook never calls super.
There is a particular example in the purchasing app.
When searching for products when creating a purchase line, you can no longer search by the supplier code because this _name_search hook doesn't allow the _name_search hook in the product module to run.